### PR TITLE
fix: support OpenSSH format private keys

### DIFF
--- a/packages/sftp/lib/sftp/ssh.mjs
+++ b/packages/sftp/lib/sftp/ssh.mjs
@@ -1,12 +1,28 @@
+import { existsSync } from 'node:fs';
+
 import { NodeSSH } from 'node-ssh';
+import { utils as ssh2Utils } from 'ssh2';
 
 import { logger } from './logger.mjs';
 
 export function SSH({ user, hostname, port, key }, callback) {
   const ssh = new NodeSSH();
 
-  // Check if key is inline PEM format (supports RSA, Ed25519, ECDSA, etc.)
-  const isInlineKey = /^-----BEGIN .+ PRIVATE KEY-----/.test(key);
+  // Determine if key is a file path or inline key content
+  let connectOptions;
+  
+  if (existsSync(key)) {
+    // File exists, use as privateKeyPath
+    connectOptions = { privateKeyPath: key };
+  } else {
+    // Treat as inline key content, validate format
+    try {
+      ssh2Utils.parseKey(key);
+      connectOptions = { privateKey: key };
+    } catch (error) {
+      throw new Error(`Invalid private key format: ${error.message}`);
+    }
+  }
 
   return ssh
     .connect({
@@ -15,9 +31,7 @@ export function SSH({ user, hostname, port, key }, callback) {
       username: user,
       tryKeyboard: false,
       keepaliveInterval: 30 * 1000,
-      ...(isInlineKey
-        ? { privateKey: key }
-        : { privateKeyPath: key }),
+      ...connectOptions,
     })
     .then(() => {
       logger.info('Connection:', 'start');

--- a/packages/sftp/lib/sftp/ssh.mjs
+++ b/packages/sftp/lib/sftp/ssh.mjs
@@ -1,7 +1,6 @@
 import { existsSync } from 'node:fs';
 
 import { NodeSSH } from 'node-ssh';
-import { utils as ssh2Utils } from 'ssh2';
 
 import { logger } from './logger.mjs';
 
@@ -19,16 +18,9 @@ export function SSH({ user, hostname, port, key }, callback) {
 
   // Determine if key is a file path or inline key content
   if (existsSync(key)) {
-    // File exists, use as privateKeyPath
     connectOptions.privateKeyPath = key;
   } else {
-    // Treat as inline key content, validate format
-    try {
-      ssh2Utils.parseKey(key);
-      connectOptions.privateKey = key;
-    } catch (error) {
-      throw new Error(`Invalid private key format: ${error.message}`);
-    }
+    connectOptions.privateKey = key;
   }
 
   return ssh

--- a/packages/sftp/lib/sftp/ssh.mjs
+++ b/packages/sftp/lib/sftp/ssh.mjs
@@ -8,31 +8,31 @@ import { logger } from './logger.mjs';
 export function SSH({ user, hostname, port, key }, callback) {
   const ssh = new NodeSSH();
 
+  // Initialize connect options with common settings
+  const connectOptions = {
+    host: hostname,
+    port,
+    username: user,
+    tryKeyboard: false,
+    keepaliveInterval: 30 * 1000,
+  };
+
   // Determine if key is a file path or inline key content
-  let connectOptions;
-  
   if (existsSync(key)) {
     // File exists, use as privateKeyPath
-    connectOptions = { privateKeyPath: key };
+    connectOptions.privateKeyPath = key;
   } else {
     // Treat as inline key content, validate format
     try {
       ssh2Utils.parseKey(key);
-      connectOptions = { privateKey: key };
+      connectOptions.privateKey = key;
     } catch (error) {
       throw new Error(`Invalid private key format: ${error.message}`);
     }
   }
 
   return ssh
-    .connect({
-      host: hostname,
-      port,
-      username: user,
-      tryKeyboard: false,
-      keepaliveInterval: 30 * 1000,
-      ...connectOptions,
-    })
+    .connect(connectOptions)
     .then(() => {
       logger.info('Connection:', 'start');
 

--- a/packages/sftp/lib/sftp/ssh.mjs
+++ b/packages/sftp/lib/sftp/ssh.mjs
@@ -5,6 +5,9 @@ import { logger } from './logger.mjs';
 export function SSH({ user, hostname, port, key }, callback) {
   const ssh = new NodeSSH();
 
+  // Check if key is inline PEM format (supports RSA, Ed25519, ECDSA, etc.)
+  const isInlineKey = /^-----BEGIN .+ PRIVATE KEY-----/.test(key);
+
   return ssh
     .connect({
       host: hostname,
@@ -12,7 +15,7 @@ export function SSH({ user, hostname, port, key }, callback) {
       username: user,
       tryKeyboard: false,
       keepaliveInterval: 30 * 1000,
-      ...(key.startsWith('-----BEGIN RSA PRIVATE KEY-----')
+      ...(isInlineKey
         ? { privateKey: key }
         : { privateKeyPath: key }),
     })

--- a/packages/sftp/lib/sftp/ssh.mjs
+++ b/packages/sftp/lib/sftp/ssh.mjs
@@ -7,24 +7,17 @@ import { logger } from './logger.mjs';
 export function SSH({ user, hostname, port, key }, callback) {
   const ssh = new NodeSSH();
 
-  // Initialize connect options with common settings
-  const connectOptions = {
-    host: hostname,
-    port,
-    username: user,
-    tryKeyboard: false,
-    keepaliveInterval: 30 * 1000,
-  };
-
-  // Determine if key is a file path or inline key content
-  if (existsSync(key)) {
-    connectOptions.privateKeyPath = key;
-  } else {
-    connectOptions.privateKey = key;
-  }
-
   return ssh
-    .connect(connectOptions)
+    .connect({
+      host: hostname,
+      port,
+      username: user,
+      tryKeyboard: false,
+      keepaliveInterval: 30 * 1000,
+      ...(existsSync(key)
+        ? { privateKeyPath: key }
+        : { privateKey: key }),
+    })
     .then(() => {
       logger.info('Connection:', 'start');
 


### PR DESCRIPTION
- 主要的问题是原来的 key 检测只能支持 `BEGIN RSA PRIVATE KEY`, 但是手头的 key 是 `BEGIN OPENSSH PRIVATE KEY`, 所以没法用
- 使用 fs.existsSync() 来检查 key 作为路径的合法性

已经查看了 node-ssh 和 ssh2 的实现，node-ssh 需要明确区分 privateKey 和 privateKeyPath，不支持混用。而 ssh2 在 connect 前会使用 ssh2.utils.parseKey() 来校验 privateKey 的正确性。所以在此只需要简洁地判断 key 是否是路径即可。

建议 squash merge ，因为 Copilot 写的有点太碎了
